### PR TITLE
Simplify CCClass 1 - 解除 CCClass 的封印

### DIFF
--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1491,6 +1491,7 @@ Unknown 'type' parameter of %s.%s：%s
 
 ### 3647
 
+<!-- DEPRECATED -->
 The length of range array must be equal or greater than 2
 
 ### 3648
@@ -2282,14 +2283,17 @@ Can not serialize '%s.%s' because the specified type is anonymous, please provid
 
 ### 5513
 
+<!-- DEPRECATED -->
 The 'default' value of '%s.%s' should not be used with a 'get' function.
 
 ### 5514
 
+<!-- DEPRECATED -->
 The 'default' value of '%s.%s' should not be used with a 'set' function.
 
 ### 5515
 
+<!-- DEPRECATED -->
 The 'default' value of '%s.%s' can not be an constructor. Set default to null please.
 
 ### 5516

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1302,6 +1302,7 @@ Use 'cc.Float' or 'cc.Integer' instead of 'cc.Number' please.
 
 ### 3604
 
+<!-- DEPRECATED -->
 Can only indicate one type attribute for %s.
 
 ### 3605
@@ -1334,7 +1335,7 @@ Can not indicate the '%s' attribute for %s, which its default value is type of %
 
 ### 3612
 
-%s Just set the default value to 'new %s()' and it will be handled properly.
+%s Simply assign 'new %s()' as the default value, and it will be managed correctly.
 
 ### 3613
 

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1447,6 +1447,7 @@ Do not set default value to non-empty object, unless the object defines its own 
 
 ### 3637
 
+<!-- DEPRECATED -->
 Can not declare %s.%s, it is already defined in the prototype of %s
 
 ### 3638

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1522,6 +1522,7 @@ Please ensure the constructor can be called during the script's initialization.
 
 ### 3653
 
+<!-- DEPRECATED -->
 Please do not specifiy "default" attribute in decorator of "%s" property in "%s" class.
 Default value must be initialized at their declaration:
 
@@ -1554,6 +1555,7 @@ myProp = 0;
 
 ### 3655
 
+<!-- DEPRECATED -->
 Can not specifiy "get" or "set"  attribute in decorator for "%s" property in "%s" class.
 Please use:
 

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -2222,10 +2222,12 @@ Class should be extended before assigning any prototype members.
 
 ### 5500
 
+<!-- DEPRECATED -->
 'notify' can not be used in 'get/set' !
 
 ### 5501
 
+<!-- DEPRECATED -->
 'notify' must be used with 'default' !
 
 ### 5502

--- a/EngineErrorMap.md
+++ b/EngineErrorMap.md
@@ -1293,6 +1293,7 @@ The editor property 'playOnFocus' should be used with 'executeInEditMode' in cla
 
 ### 3602
 
+<!-- DEPRECATED -->
 Unknown editor property '%s' in class '%s'.
 
 ### 3603
@@ -1382,6 +1383,7 @@ Unknown type of %s.%s, property should be defined in 'properties' or 'ctor'
 
 ### 3623
 
+<!-- DEPRECATED -->
 Can not use 'editor' attribute, '%s' not inherits from Components.
 
 ### 3624

--- a/cocos/animation/marionette/pose-graph/decorator/input.ts
+++ b/cocos/animation/marionette/pose-graph/decorator/input.ts
@@ -3,6 +3,7 @@
 import { error, js } from '../../../../core';
 import { PropertyStashInternalFlag } from '../../../../core/data/class-stash';
 import { getOrCreatePropertyStash } from '../../../../core/data/decorators/property';
+import { LegacyPropertyDecorator } from '../../../../core/data/decorators/utils';
 import { PoseGraphNodeInputMappingOptions, globalPoseGraphNodeInputManager } from '../foundation/authoring/input-authoring';
 import { PoseGraphType } from '../foundation/type-system';
 import { PoseNode } from '../pose-node';
@@ -38,8 +39,8 @@ export type { PoseGraphNodeInputMappingOptions };
  * If the decorating property is **NOT** an array, the property will be mapped as an input.
  * Otherwise, each element of the property will be mapped as an input.
  */
-export function input (options: PoseGraphNodeInputMappingOptions): PropertyDecorator {
-    return (target, propertyKey): void => {
+export function input (options: PoseGraphNodeInputMappingOptions): LegacyPropertyDecorator {
+    return (target, propertyKey, descriptorOrInitializer): void => {
         const targetConstructor = target.constructor;
         if (options.type === PoseGraphType.POSE) {
             if (!js.isChildClassOf(targetConstructor, PoseNode)) {
@@ -53,7 +54,7 @@ export function input (options: PoseGraphNodeInputMappingOptions): PropertyDecor
             error(`@input can be only applied to fields of subclasses of PoseNode or PureValueNode.`);
             return;
         }
-        inputUnchecked(options)(target, propertyKey);
+        inputUnchecked(options)(target, propertyKey, descriptorOrInitializer);
     };
 }
 
@@ -61,8 +62,8 @@ export function input (options: PoseGraphNodeInputMappingOptions): PropertyDecor
  * Unchecked version of `@input()`.
  * @internal
  */
-export function inputUnchecked (options: PoseGraphNodeInputMappingOptions): PropertyDecorator {
-    return (target, propertyKey) => {
+export function inputUnchecked (options: PoseGraphNodeInputMappingOptions): LegacyPropertyDecorator {
+    return (target, propertyKey, descriptorOrInitializer) => {
         if (typeof propertyKey !== 'string') {
             error(`@input can be only applied to string-named fields.`);
             return;
@@ -71,7 +72,7 @@ export function inputUnchecked (options: PoseGraphNodeInputMappingOptions): Prop
         const targetConstructor = target.constructor;
         globalPoseGraphNodeInputManager.setPropertyNodeInputRecord(targetConstructor, propertyKey, options);
 
-        const propertyStash = getOrCreatePropertyStash(target, propertyKey);
+        const propertyStash = getOrCreatePropertyStash(target, propertyKey, descriptorOrInitializer);
         propertyStash.__internalFlags |= (PropertyStashInternalFlag.STANDALONE | PropertyStashInternalFlag.IMPLICIT_VISIBLE);
     };
 }

--- a/cocos/core/data/class-stash.ts
+++ b/cocos/core/data/class-stash.ts
@@ -37,14 +37,9 @@ export interface ClassStash {
     default?: unknown;
 
     /**
-     * Just a kind of organization.
+     * The property stashes.
      */
-    proto?: {
-        /**
-         * The property stashes.
-         */
-        properties?: Record<PropertyKey, PropertyStash>;
-    };
+    properties?: Record<PropertyKey, PropertyStash>;
 
     /**
      * The error properties.

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -354,20 +354,15 @@ interface IParsedAttribute extends IAcceptableAttributes {
 }
 
 function parseAttributes (constructor: Function, attributes: PropertyStash, className: string, propertyName: string, usedInGetter): void {
-    let attrs: IParsedAttribute | null = null;
-    let propertyNamePrefix = '';
-    function initAttrs (): any {
-        propertyNamePrefix = propertyName + DELIMETER;
-        return attrs = attributeUtils.getClassAttrs(constructor);
-    }
-
+    const attrs: IParsedAttribute = attributeUtils.getClassAttrs(constructor);
+    const propertyNamePrefix = propertyName + DELIMETER;
     let warnOnNoDefault = true;
 
     const type = attributes.type;
     if (type) {
         const primitiveType = PrimitiveTypes[type];
         if (primitiveType) {
-            (attrs || initAttrs())[`${propertyNamePrefix}type`] = type;
+            attrs[`${propertyNamePrefix}type`] = type;
 
             // Ensures the type matches its default value
             if (((EDITOR && !window.Build) || TEST) && !attributes._short) {
@@ -407,21 +402,21 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
         else if (typeof type === 'object') {
             if (Enum.isEnum(type)) {
                 setPropertyEnumTypeOnAttrs(
-                    attrs || initAttrs(),
+                    attrs,
                     propertyName,
                     type,
                 );
             } else if (BitMask.isBitMask(type)) {
-                (attrs || initAttrs())[`${propertyNamePrefix}type`] = BITMASK_TAG;
-                attrs![`${propertyNamePrefix}bitmaskList`] = BitMask.getList(type);
+                attrs[`${propertyNamePrefix}type`] = BITMASK_TAG;
+                attrs[`${propertyNamePrefix}bitmaskList`] = BitMask.getList(type);
             } else if (DEV) {
                 errorID(3645, className, propertyName, type);
             }
         } else if (typeof type === 'function') {
             // Do not warn missing-default if the type is object
             warnOnNoDefault = false;
-            (attrs || initAttrs())[`${propertyNamePrefix}type`] = 'Object';
-            attrs![`${propertyNamePrefix}ctor`] = type;
+            attrs[`${propertyNamePrefix}type`] = 'Object';
+            attrs[`${propertyNamePrefix}ctor`] = type;
 
             // Ensures the type matches its default value
             if (((EDITOR && !window.Build) || TEST) && !attributes._short) {
@@ -454,7 +449,7 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     }
 
     if ('default' in attributes) {
-        (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
+        attrs[`${propertyNamePrefix}default`] = attributes.default;
     }
     // TODO: we close this warning for now:
     // issue: https://github.com/cocos/3d-tasks/issues/14887
@@ -463,9 +458,9 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     // }
 
     const parseSimpleAttribute = (attributeName: keyof IAcceptableAttributes): void => {
-        if (attributeName in attributes) {
-            const val = attributes[attributeName];
-            (attrs || initAttrs())[propertyNamePrefix + attributeName] = val;
+        const val = attributes[attributeName];
+        if (val || attributeName in attributes) {
+            attrs[propertyNamePrefix + attributeName] = val;
         }
     };
 
@@ -473,7 +468,7 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
         if (usedInGetter) {
             errorID(3613, 'editorOnly', className, propertyName);
         } else {
-            (attrs || initAttrs())[`${propertyNamePrefix}editorOnly`] = true;
+            attrs[`${propertyNamePrefix}editorOnly`] = true;
         }
     }
     if (DEV) {
@@ -503,7 +498,7 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
         }
     }
     if (typeof normalizedSerializable !== 'undefined') {
-        (attrs || initAttrs())[`${propertyNamePrefix}serializable`] = normalizedSerializable;
+        attrs[`${propertyNamePrefix}serializable`] = normalizedSerializable;
     }
 
     parseSimpleAttribute('formerlySerializedAs');
@@ -534,17 +529,17 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
         }
 
         if (typeof normalizedVisible !== 'undefined') {
-            (attrs || initAttrs())[`${propertyNamePrefix}visible`] = normalizedVisible;
+            attrs[`${propertyNamePrefix}visible`] = normalizedVisible;
         }
     }
 
     if (DEV) {
         const range = attributes.range;
         if (range) {
-            (attrs || initAttrs())[`${propertyNamePrefix}min`] = range[0];
-            attrs![`${propertyNamePrefix}max`] = range[1];
+            attrs[`${propertyNamePrefix}min`] = range[0];
+            attrs[`${propertyNamePrefix}max`] = range[1];
             if (range.length > 2) {
-                attrs![`${propertyNamePrefix}step`] = range[2];
+                attrs[`${propertyNamePrefix}step`] = range[2];
             }
         }
         parseSimpleAttribute('min');

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -307,15 +307,6 @@ export function CCClass<TFunction> (options: {
     const properties = options.properties;
     declareProperties(cls, name, properties, base);
 
-    const editor = options.editor;
-    if (editor) {
-        if (js.isChildClassOf(base, legacyCC.Component)) {
-            legacyCC.Component._registerEditorProps(cls, editor);
-        } else if (DEV) {
-            warnID(3623, name!);
-        }
-    }
-
     return cls;
 }
 

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -149,14 +149,14 @@ function define (cls, className, baseClass): any {
 
     if (EDITOR) {
         // for RenderPipeline, RenderFlow, RenderStage
-            let renderName = '';
+        let renderName = '';
         if (isChildClassOf(baseClass, legacyCC.RenderPipeline)) {
-                renderName = 'render_pipeline';
+            renderName = 'render_pipeline';
         } else if (isChildClassOf(baseClass, legacyCC.RenderFlow)) {
-                renderName = 'render_flow';
+            renderName = 'render_flow';
         } else if (isChildClassOf(baseClass, legacyCC.RenderStage)) {
-                renderName = 'render_stage';
-            }
+            renderName = 'render_stage';
+        }
         if (renderName) {
             // 增加了 hidden: 开头标识，使它最终不会显示在 Editor inspector 的添加组件列表里
             window.EditorExtends && window.EditorExtends.Component.addMenu(cls, `hidden:${renderName}/${className}`, -1);
@@ -250,7 +250,7 @@ interface ISealable {
 
 export function CCClass<TFunction> (
     cls: TFunction & ISealable,
-    base: null | (Function & { __props__?: any } & ISealable),
+    base: null | (TFunction & { __props__?: any } & ISealable),
     name?: string,
     properties?: any,
     ): any {
@@ -427,16 +427,16 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     if ('default' in attributes) {
         (attrs || initAttrs())[`${propertyNamePrefix}default`] = attributes.default;
     }
-        // TODO: we close this warning for now:
-        // issue: https://github.com/cocos/3d-tasks/issues/14887
+    // TODO: we close this warning for now:
+    // issue: https://github.com/cocos/3d-tasks/issues/14887
     // else if (((EDITOR && !window.Build) || TEST) && warnOnNoDefault && !(attributes.get || attributes.set)) {
-        // warnID(3654, className, propertyName);
+    //     warnID(3654, className, propertyName);
     // }
 
     const parseSimpleAttribute = (attributeName: keyof IAcceptableAttributes): void => {
         if (attributeName in attributes) {
             const val = attributes[attributeName];
-                (attrs || initAttrs())[propertyNamePrefix + attributeName] = val;
+            (attrs || initAttrs())[propertyNamePrefix + attributeName] = val;
         }
     };
 
@@ -489,20 +489,20 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
 
         let normalizedVisible: undefined | boolean | (() => boolean);
         switch (typeof visible) {
-        case 'boolean':
-        case 'function':
-            normalizedVisible = visible;
-            break;
-        default: {
-            if (isStandaloneMode) {
-                normalizedVisible = (attributes.__internalFlags & PropertyStashInternalFlag.IMPLICIT_VISIBLE) !== 0;
-            } else {
-                const startsWithUS = (propertyName.charCodeAt(0) === 95);
-                if (startsWithUS) {
-                    normalizedVisible = false;
+            case 'boolean':
+            case 'function':
+                normalizedVisible = visible;
+                break;
+            default: {
+                if (isStandaloneMode) {
+                    normalizedVisible = (attributes.__internalFlags & PropertyStashInternalFlag.IMPLICIT_VISIBLE) !== 0;
+                } else {
+                    const startsWithUS = (propertyName.charCodeAt(0) === 95);
+                    if (startsWithUS) {
+                        normalizedVisible = false;
+                    }
                 }
             }
-        }
         }
 
         if (typeof normalizedVisible !== 'undefined') {
@@ -511,13 +511,13 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
     }
 
     if (DEV) {
-    const range = attributes.range;
-    if (range) {
-                (attrs || initAttrs())[`${propertyNamePrefix}min`] = range[0];
-                attrs![`${propertyNamePrefix}max`] = range[1];
-                if (range.length > 2) {
-                    attrs![`${propertyNamePrefix}step`] = range[2];
-                }
+        const range = attributes.range;
+        if (range) {
+            (attrs || initAttrs())[`${propertyNamePrefix}min`] = range[0];
+            attrs![`${propertyNamePrefix}max`] = range[1];
+            if (range.length > 2) {
+                attrs![`${propertyNamePrefix}step`] = range[2];
+            }
         }
         parseSimpleAttribute('min');
         parseSimpleAttribute('max');

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -379,6 +379,11 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
                             warnID(3606, `cc.${type}`, `"${className}.${propertyName}"`, defaultType);
                         }
                     } else if (type == attributeUtils.CCString && defaultValue == null) {
+                        /**
+                         * Reasons for using == instead of ===
+                         * 1. support for comparing string and object
+                         * 2. support undefined and null
+                         */
                         warnID(3607, `"${className}.${propertyName}"`);
                     } else {
                         // just check default loosely

--- a/cocos/core/data/class.ts
+++ b/cocos/core/data/class.ts
@@ -447,7 +447,6 @@ function parseAttributes (constructor: Function, attributes: PropertyStash, clas
             (attrs || initAttrs())[`${propertyNamePrefix}editorOnly`] = true;
         }
     }
-    // parseSimpleAttr('preventDeferredLoad');
     if (DEV) {
         parseSimpleAttribute('displayName');
         parseSimpleAttribute('displayOrder');

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -23,7 +23,7 @@
 */
 
 import { DEV } from 'internal:constants';
-import { getSuper, mixin, getClassName } from '../../utils/js-typed';
+import { getSuper, getClassName, isChildClassOf } from '../../utils/js-typed';
 import { CCClass } from '../class';
 import { validateOverrideMethods_DEV } from '../utils/preprocess-class';
 import { CACHE_KEY, makeSmartClassDecorator } from './utils';
@@ -58,24 +58,13 @@ export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = mak
         base = null;
     }
 
-    const proto = {
-        name,
-        extends: base,
-        ctor: constructor,
-    };
     const cache = constructor[CACHE_KEY];
+    const res = CCClass(constructor, base, name, cache?.properties);
+
     if (cache) {
-        const decoratedProto = cache.proto;
-        if (decoratedProto) {
-            // decoratedProto.properties = createProperties(ctor, decoratedProto.properties);
-            mixin(proto, decoratedProto);
-        }
         constructor[CACHE_KEY] = undefined;
     }
 
-    const res = CCClass(proto);
-
-    // validate methods
     if (DEV) {
         if (isChildClassOf(base, legacyCC.Component)) {
             if (constructor._playOnFocus && !constructor._executeInEditMode) {

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -25,8 +25,10 @@
 import { DEV } from 'internal:constants';
 import { getSuper, mixin, getClassName } from '../../utils/js-typed';
 import { CCClass } from '../class';
-import { doValidateMethodWithProps_DEV } from '../utils/preprocess-class';
+import { validateOverrideMethods_DEV } from '../utils/preprocess-class';
 import { CACHE_KEY, makeSmartClassDecorator } from './utils';
+import { legacyCC } from "../../global-exports";
+import { warnID } from "../../platform";
 
 /**
  * @en Declare a standard class as a CCClass, please refer to the [document](https://docs.cocos.com/creator3d/manual/en/scripting/ccclass.html)
@@ -75,17 +77,12 @@ export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = mak
 
     // validate methods
     if (DEV) {
-        const propNames = Object.getOwnPropertyNames(constructor.prototype);
-        for (let i = 0; i < propNames.length; ++i) {
-            const prop = propNames[i];
-            if (prop !== 'constructor') {
-                const desc = Object.getOwnPropertyDescriptor(constructor.prototype, prop);
-                const func = desc && desc.value;
-                if (typeof func === 'function') {
-                    doValidateMethodWithProps_DEV(func, prop, getClassName(constructor), constructor, base);
-                }
+        if (isChildClassOf(base, legacyCC.Component)) {
+            if (constructor._playOnFocus && !constructor._executeInEditMode) {
+                warnID(3601, name!);
             }
         }
+        validateOverrideMethods_DEV(constructor, base, getClassName(constructor));
     }
 
     return res;

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -27,8 +27,8 @@ import { getSuper, getClassName, isChildClassOf } from '../../utils/js-typed';
 import { CCClass } from '../class';
 import { validateOverrideMethods_DEV } from '../utils/preprocess-class';
 import { CACHE_KEY, makeSmartClassDecorator } from './utils';
-import { legacyCC } from "../../global-exports";
-import { warnID } from "../../platform";
+import { legacyCC } from '../../global-exports';
+import { warnID } from '../../platform';
 
 /**
  * @en Declare a standard class as a CCClass, please refer to the [document](https://docs.cocos.com/creator3d/manual/en/scripting/ccclass.html)

--- a/cocos/core/data/decorators/ccclass.ts
+++ b/cocos/core/data/decorators/ccclass.ts
@@ -67,7 +67,7 @@ export const ccclass: ((name?: string) => ClassDecorator) & ClassDecorator = mak
 
     if (DEV) {
         if (isChildClassOf(base, legacyCC.Component)) {
-            if (constructor._playOnFocus && !constructor._executeInEditMode) {
+            if ((constructor as any)._playOnFocus && !(constructor as any)._executeInEditMode) {
                 warnID(3601, name!);
             }
         }

--- a/cocos/core/data/decorators/component.ts
+++ b/cocos/core/data/decorators/component.ts
@@ -24,9 +24,9 @@
 
 import { EDITOR, TEST } from 'internal:constants';
 import { makeSmartClassDecorator, emptySmartClassDecorator } from './utils';
-import { value } from "../../utils/js";
+import { value } from '../../utils/js';
 
-export function assignEditorMetadata (constructor: Function, attrName: string, attrValue: any, inheritable: boolean) {
+export function assignEditorMetadata (constructor: Function, attrName: string, attrValue: any, inheritable: boolean): void {
     if (inheritable) {
         constructor[attrName] = attrValue;
     } else {

--- a/cocos/core/data/decorators/component.ts
+++ b/cocos/core/data/decorators/component.ts
@@ -24,6 +24,15 @@
 
 import { EDITOR, TEST } from 'internal:constants';
 import { makeSmartClassDecorator, emptySmartClassDecorator } from './utils';
+import { value } from "../../utils/js";
+
+export function assignEditorMetadata (constructor: Function, attrName: string, attrValue: any, inheritable: boolean) {
+    if (inheritable) {
+        constructor[attrName] = attrValue;
+    } else {
+        value(constructor, attrName, attrValue, true);
+    }
+}
 
 /**
  * @en Declare that the current component relies on another type of component.
@@ -47,7 +56,7 @@ export function requireComponent (requiredComponent: Function | Function[]): Cla
         if (Array.isArray(requiredComponent)) {
             requiredComponent = requiredComponent.filter(Boolean);
         }
-        constructor._requireComponent = requiredComponent;
+        assignEditorMetadata(constructor, '_requireComponent', requiredComponent, true);
     };
 }
 
@@ -71,7 +80,7 @@ export function requireComponent (requiredComponent: Function | Function[]): Cla
 export function executionOrder (priority: number): ClassDecorator {
     return <TFunction extends AnyFunction>(constructor: TFunction): void => {
         if (priority && typeof priority === 'number') {
-            constructor._executionOrder = priority;
+            assignEditorMetadata(constructor, '_executionOrder', priority, true);
         }
     };
 }
@@ -92,5 +101,5 @@ export function executionOrder (priority: number): ClassDecorator {
  * ```
  */
 export const disallowMultiple: ClassDecorator & (() => ClassDecorator) = (EDITOR || TEST) ? makeSmartClassDecorator((constructor): void => {
-    constructor._disallowMultiple = constructor;
+    assignEditorMetadata(constructor, '_disallowMultiple', constructor, true);
 }) : emptySmartClassDecorator;

--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -23,9 +23,10 @@
 */
 
 import { DEV, EDITOR, TEST } from 'internal:constants';
-import { error, warnID } from "../../platform";
-import { getClassName, value } from "../../utils/js";
+import { error } from "../../platform";
+import { getClassName } from "../../utils/js";
 import { CCClass } from "../class";
+import { assignEditorMetadata } from "./component";
 import { IExposedAttributes } from '../utils/attribute-defines';
 import { getOrCreatePropertyStash } from './property';
 import { PropertyStash, PropertyStashInternalFlag } from '../class-stash';
@@ -56,7 +57,7 @@ export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecora
     if (DEV && CCClass._isCCClass(constructor)) {
         error('`@%s` should be used after @ccclass for class "%s"', 'executeInEditMode', getClassName(constructor));
     }
-    constructor._executeInEditMode = true;
+    assignEditorMetadata(constructor, '_executeInEditMode', true, true);
 }) : emptySmartClassDecorator;
 
 /**
@@ -108,7 +109,7 @@ export const playOnFocus: ClassDecorator & ((yes?: boolean) => ClassDecorator) =
     if (DEV && CCClass._isCCClass(constructor)) {
         error('`@%s` should be used after @ccclass for class "%s"', 'playOnFocus', getClassName(constructor));
     }
-    constructor._playOnFocus = true;
+    assignEditorMetadata(constructor, '_playOnFocus', true, true);
 }) : emptySmartClassDecorator;
 
 /**
@@ -129,7 +130,7 @@ export const playOnFocus: ClassDecorator & ((yes?: boolean) => ClassDecorator) =
  */
 export const inspector: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
     return <TFunction extends AnyFunction>(constructor: TFunction): void => {
-        value(constructor, '_inspector', url, true);
+        assignEditorMetadata(constructor, '_inspector', url, false);
     };
 }) : emptyDecoratorFn;
 
@@ -152,7 +153,7 @@ export const inspector: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((u
  */
 export const icon: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
     return <TFunction extends AnyFunction>(constructor: TFunction): void => {
-        value(constructor, '_icon', url, true);
+        assignEditorMetadata(constructor, '_icon', url, false);
     };
 }) : emptyDecoratorFn;
 
@@ -175,7 +176,7 @@ export const icon: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: s
  */
 export const help: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
     return <TFunction extends AnyFunction>(constructor: TFunction): void => {
-        constructor._help = url;
+        assignEditorMetadata(constructor, '_help', url, true);
     };
 }) : emptyDecoratorFn;
 

--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -23,8 +23,9 @@
 */
 
 import { DEV, EDITOR, TEST } from 'internal:constants';
-import { warnID } from "../../platform";
-import { value } from "../../utils/js";
+import { error, warnID } from "../../platform";
+import { getClassName, value } from "../../utils/js";
+import { CCClass } from "../class";
 import { IExposedAttributes } from '../utils/attribute-defines';
 import { getOrCreatePropertyStash } from './property';
 import { PropertyStash, PropertyStashInternalFlag } from '../class-stash';
@@ -52,6 +53,9 @@ import * as RF from "../utils/requiring-frame";
  * ```
  */
 export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecorator) = (EDITOR || TEST) ? makeSmartClassDecorator((constructor): void => {
+    if (DEV && CCClass._isCCClass(constructor)) {
+        error('`@%s` should be used after @ccclass for class "%s"', 'executeInEditMode', getClassName(constructor));
+    }
     constructor._executeInEditMode = true;
 }) : emptySmartClassDecorator;
 
@@ -101,6 +105,9 @@ export const menu: (path: string) => ClassDecorator = (EDITOR || TEST) ? ((path:
  * ```
  */
 export const playOnFocus: ClassDecorator & ((yes?: boolean) => ClassDecorator) = (EDITOR || TEST) ? makeSmartClassDecorator((constructor): void => {
+    if (DEV && CCClass._isCCClass(constructor)) {
+        error('`@%s` should be used after @ccclass for class "%s"', 'playOnFocus', getClassName(constructor));
+    }
     constructor._playOnFocus = true;
 }) : emptySmartClassDecorator;
 

--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -23,17 +23,17 @@
 */
 
 import { DEV, EDITOR, TEST } from 'internal:constants';
-import { error } from "../../platform";
-import { getClassName } from "../../utils/js";
-import { CCClass } from "../class";
-import { assignEditorMetadata } from "./component";
+import { error } from '../../platform';
+import { getClassName } from '../../utils/js';
+import { CCClass } from '../class';
+import { assignEditorMetadata } from './component';
 import { IExposedAttributes } from '../utils/attribute-defines';
 import { getOrCreatePropertyStash } from './property';
 import { PropertyStash, PropertyStashInternalFlag } from '../class-stash';
 
 import { LegacyPropertyDecorator, emptyDecorator, makeSmartClassDecorator, emptySmartClassDecorator, emptyDecoratorFn } from './utils';
 
-import * as RF from "../utils/requiring-frame";
+import * as RF from '../utils/requiring-frame';
 
 /**
  * @en Makes a CCClass that inherits from component execute in edit mode.<br/>
@@ -53,12 +53,13 @@ import * as RF from "../utils/requiring-frame";
  * }
  * ```
  */
-export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecorator) = (EDITOR || TEST) ? makeSmartClassDecorator((constructor): void => {
-    if (DEV && CCClass._isCCClass(constructor)) {
-        error('`@%s` should be used after @ccclass for class "%s"', 'executeInEditMode', getClassName(constructor));
-    }
-    assignEditorMetadata(constructor, '_executeInEditMode', true, true);
-}) : emptySmartClassDecorator;
+export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecorator) = (EDITOR || TEST) ?
+    makeSmartClassDecorator((constructor): void => {
+        if (DEV && CCClass._isCCClass(constructor)) {
+            error('`@%s` should be used after @ccclass for class "%s"', 'executeInEditMode', getClassName(constructor));
+        }
+        assignEditorMetadata(constructor, '_executeInEditMode', true, true);
+    }) : emptySmartClassDecorator;
 
 /**
  * @en Add the current component to the specific menu path in `Add Component` selector of the inspector panel
@@ -76,8 +77,8 @@ export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecora
  * }
  * ```
  */
-export const menu: (path: string) => ClassDecorator = EDITOR ? ((path: string): ClassDecorator => {
-    return <TFunction extends AnyFunction>(constructor: TFunction): void => {
+export const menu: (path: string) => ClassDecorator = EDITOR ? ((path: string): ClassDecorator =>
+    <TFunction extends AnyFunction>(constructor: TFunction): void => {
         const frame = RF.peek();
         if (frame && !path.includes('/')) {
             path = `i18n:menu.custom_script/${path}`;
@@ -85,8 +86,8 @@ export const menu: (path: string) => ClassDecorator = EDITOR ? ((path: string): 
 
         EditorExtends.Component.removeMenu(constructor);
         EditorExtends.Component.addMenu(constructor, path /*, props.menuPriority */);
-    };
-}) : emptyDecoratorFn;
+    }
+) : emptyDecoratorFn;
 
 /**
  * @en When [[_decorator.executeInEditMode]] is set,
@@ -128,11 +129,11 @@ export const playOnFocus: ClassDecorator & ((yes?: boolean) => ClassDecorator) =
  * }
  * ```
  */
-export const inspector: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
-    return <TFunction extends AnyFunction>(constructor: TFunction): void => {
+export const inspector: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator =>
+    <TFunction extends AnyFunction>(constructor: TFunction): void => {
         assignEditorMetadata(constructor, '_inspector', url, false);
-    };
-}) : emptyDecoratorFn;
+    }
+) : emptyDecoratorFn;
 
 /**
  * @en Define the icon of the component.
@@ -151,11 +152,11 @@ export const inspector: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((u
  * }
  * ```
  */
-export const icon: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
-    return <TFunction extends AnyFunction>(constructor: TFunction): void => {
+export const icon: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator =>
+    <TFunction extends AnyFunction>(constructor: TFunction): void => {
         assignEditorMetadata(constructor, '_icon', url, false);
-    };
-}) : emptyDecoratorFn;
+    }
+) : emptyDecoratorFn;
 
 /**
  * @en Define the help documentation URL,
@@ -174,11 +175,11 @@ export const icon: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: s
  * }
  * ```
  */
-export const help: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator => {
-    return <TFunction extends AnyFunction>(constructor: TFunction): void => {
+export const help: (url: string) => ClassDecorator = (EDITOR || TEST) ? ((url: string): ClassDecorator =>
+    <TFunction extends AnyFunction>(constructor: TFunction): void => {
         assignEditorMetadata(constructor, '_help', url, true);
-    };
-}) : emptyDecoratorFn;
+    }
+) : emptyDecoratorFn;
 
 /**
  * @en

--- a/cocos/core/data/decorators/editable.ts
+++ b/cocos/core/data/decorators/editable.ts
@@ -76,7 +76,7 @@ export const executeInEditMode: ClassDecorator & ((yes?: boolean) => ClassDecora
  * }
  * ```
  */
-export const menu: (path: string) => ClassDecorator = (EDITOR || TEST) ? ((path: string): ClassDecorator => {
+export const menu: (path: string) => ClassDecorator = EDITOR ? ((path: string): ClassDecorator => {
     return <TFunction extends AnyFunction>(constructor: TFunction): void => {
         const frame = RF.peek();
         if (frame && !path.includes('/')) {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -144,9 +144,8 @@ function getOrCreateEmptyPropertyStash (
     target: Parameters<LegacyPropertyDecorator>[0],
     propertyKey: Parameters<LegacyPropertyDecorator>[1],
 ): PropertyStash {
-    const classStash = getClassCache(target.constructor) as ClassStash;
-    const ccclassProto = getSubDict(classStash, 'proto');
-    const properties = getSubDict(ccclassProto, 'properties');
+    const classStash = getClassCache(target.constructor);
+    const properties = getSubDict(classStash, 'properties');
     const propertyStash = properties[(propertyKey as string)] ??= {} as PropertyStash;
     return propertyStash;
 }
@@ -156,9 +155,8 @@ export function getOrCreatePropertyStash (
     propertyKey: Parameters<LegacyPropertyDecorator>[1],
     descriptorOrInitializer?: Parameters<LegacyPropertyDecorator>[2],
 ): PropertyStash {
-    const classStash = getClassCache(target.constructor) as ClassStash;
-    const ccclassProto = getSubDict(classStash, 'proto');
-    const properties = getSubDict(ccclassProto, 'properties');
+    const classStash = getClassCache(target.constructor);
+    const properties = getSubDict(classStash, 'properties');
     const propertyStash = properties[(propertyKey as string)] ??= {} as PropertyStash;
     propertyStash.__internalFlags |= PropertyStashInternalFlag.STANDALONE;
     if (descriptorOrInitializer && typeof descriptorOrInitializer !== 'function' && (descriptorOrInitializer.get || descriptorOrInitializer.set)) {

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -75,12 +75,10 @@ export function property (
         propertyKey: Parameters<LegacyPropertyDecorator>[1],
         descriptorOrInitializer: Parameters<LegacyPropertyDecorator>[2],
     ): void {
-        const classStash = getClassCache(target.constructor);
-        const propertyStash = getOrCreateEmptyPropertyStash(
-            target,
-            propertyKey,
-        );
         const classConstructor = target.constructor;
+        const classStash = getClassCache(classConstructor);
+        const properties = getSubDict(classStash, 'properties');
+        const propertyStash = properties[(propertyKey as string)] ??= {} as PropertyStash;
         mergePropertyOptions(
             classStash,
             propertyStash,
@@ -127,27 +125,15 @@ function getDefaultFromInitializer (initializer: Initializer): unknown {
 }
 
 function extractActualDefaultValues (classConstructor: new () => unknown): unknown {
-    let dummyObj: unknown;
     try {
         // eslint-disable-next-line new-cap
-        dummyObj = new classConstructor();
+        return new classConstructor();
     } catch (e) {
         if (DEV) {
             warnID(3652, getClassName(classConstructor), e);
         }
         return {};
     }
-    return dummyObj;
-}
-
-function getOrCreateEmptyPropertyStash (
-    target: Parameters<LegacyPropertyDecorator>[0],
-    propertyKey: Parameters<LegacyPropertyDecorator>[1],
-): PropertyStash {
-    const classStash = getClassCache(target.constructor);
-    const properties = getSubDict(classStash, 'properties');
-    const propertyStash = properties[(propertyKey as string)] ??= {} as PropertyStash;
-    return propertyStash;
 }
 
 export function getOrCreatePropertyStash (

--- a/cocos/core/data/decorators/property.ts
+++ b/cocos/core/data/decorators/property.ts
@@ -75,7 +75,7 @@ export function property (
         propertyKey: Parameters<LegacyPropertyDecorator>[1],
         descriptorOrInitializer: Parameters<LegacyPropertyDecorator>[2],
     ): void {
-        const classStash = getOrCreateClassStash(target);
+        const classStash = getClassCache(target.constructor);
         const propertyStash = getOrCreateEmptyPropertyStash(
             target,
             propertyKey,
@@ -138,11 +138,6 @@ function extractActualDefaultValues (classConstructor: new () => unknown): unkno
         return {};
     }
     return dummyObj;
-}
-
-function getOrCreateClassStash (target: Parameters<LegacyPropertyDecorator>[0]): ClassStash {
-    const cache = getClassCache(target.constructor) as ClassStash;
-    return cache;
 }
 
 function getOrCreateEmptyPropertyStash (

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 */
 
-import { ClassStash } from "../class-stash";
+import { ClassStash } from '../class-stash';
 
 export type Initializer = () => unknown;
 

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -103,47 +103,6 @@ export function makeSmartClassDecorator<TArg> (
     }
 }
 
-function writeEditorClassProperty<TValue> (constructor: AnyFunction, propertyName: string, value: TValue): void {
-    const cache = getClassCache(constructor, propertyName);
-    if (cache) {
-        const proto = getSubDict(cache, 'proto');
-        getSubDict(proto, 'editor')[propertyName] = value;
-    }
-}
-
-/**
- * @en
- * Make a function that accepts an argument value and returns a class decorator.
- * The decorator sets the editor property `propertyName`, on the decorated class, into that argument value.
- * @zh
- * 创建一个函数，该函数接受一个参数值并返回一个类装饰器。
- * 该装饰器将被装饰类的编辑器属性 `propertyName` 设置为该参数的值。
- * @param propertyName The editor property.
- */
-export function makeEditorClassDecoratorFn<TValue> (propertyName: string): (value: TValue) => ClassDecorator {
-    return (value: TValue) => <TFunction extends AnyFunction>(constructor: TFunction): void => {
-        writeEditorClassProperty(constructor, propertyName, value);
-    };
-}
-
-/**
- * Make a smart class decorator.
- * The smart decorator sets the editor property `propertyName`, on the decorated class, into:
- * - `defaultValue` if the decorator is called with `@x` form, or
- * - the argument if the decorator is called with an argument, eg, the `@x(arg0)` form.
- * @zh
- * 创建一个智能类装饰器。
- * 该智能类装饰器将根据以下情况来设置被装饰类的编辑器属性 `propertyName`：
- * - 如果该装饰器是以 `@x` 形式调用的，该属性将被设置为 `defaultValue`。
- * - 如果该装饰器是以一个参数的形式，即 `@x(arg0)` 的形式调用的，该属性将被设置为传入的参数值。
- * @param propertyName The editor property.
- */
-export function makeSmartEditorClassDecorator<TValue> (propertyName: string, defaultValue: TValue): ClassDecorator & ((arg?: TValue | undefined) => ClassDecorator) {
-    return makeSmartClassDecorator<TValue>((constructor, decoratedValue?: TValue): void => {
-        writeEditorClassProperty(constructor, propertyName, (defaultValue !== undefined) ? defaultValue : decoratedValue);
-    });
-}
-
 // caches for class construction
 export const CACHE_KEY = '__ccclassCache__';
 

--- a/cocos/core/data/decorators/utils.ts
+++ b/cocos/core/data/decorators/utils.ts
@@ -22,10 +22,7 @@
  THE SOFTWARE.
 */
 
-import { DEV } from 'internal:constants';
-import { CCClass } from '../class';
-import { error } from '../../platform/debug';
-import { getClassName } from '../../utils/js-typed';
+import { ClassStash } from "../class-stash";
 
 export type Initializer = () => unknown;
 
@@ -106,13 +103,8 @@ export function makeSmartClassDecorator<TArg> (
 // caches for class construction
 export const CACHE_KEY = '__ccclassCache__';
 
-export function getClassCache (ctor, decoratorName?): any {
-    if (DEV && CCClass._isCCClass(ctor)) {
-        error('`@%s` should be used after @ccclass for class "%s"', decoratorName, getClassName(ctor));
-        return null;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return getSubDict(ctor, CACHE_KEY);
+export function getClassCache (ctor): ClassStash {
+    return getSubDict(ctor, CACHE_KEY) as ClassStash;
 }
 
 export function getSubDict<T, TKey extends keyof T> (obj: T, key: TKey): NonNullable<T[TKey]> {

--- a/cocos/core/data/utils/attribute-defines.ts
+++ b/cocos/core/data/utils/attribute-defines.ts
@@ -100,7 +100,7 @@ export interface IExposedAttributes {
     /**
      * 当该属性为数值类型时，指定了该属性允许的范围。
      */
-    range?: number[];
+    range?: [number, number, number?];
 
     /**
      * 当该属性为数值类型时，是否在编辑器中提供滑动条来调节值。

--- a/cocos/core/data/utils/preprocess-class.ts
+++ b/cocos/core/data/utils/preprocess-class.ts
@@ -70,6 +70,11 @@ function parseType (val, type, className, propName): void {
                 warnID(3610, `"${className}.${propName}"`);
             }
         }
+        if (EDITOR) {
+            if (legacyCC.Class._isCCClass(type) && val.serializable !== false && !js.getClassId(type, false)) {
+                warnID(5512, className, propName, className, propName);
+            }
+        }
     } else if (STATIC_CHECK) {
         switch (type) {
         case 'Number':
@@ -90,12 +95,6 @@ function parseType (val, type, className, propName): void {
         case null:
             warnID(5511, className, propName);
             break;
-        }
-    }
-
-    if (EDITOR && typeof type === 'function') {
-        if (legacyCC.Class._isCCClass(type) && val.serializable !== false && !js.getClassId(type, false)) {
-            warnID(5512, className, propName, className, propName);
         }
     }
 }
@@ -158,18 +157,6 @@ export function preprocessAttrs (properties, className, cls): void {
             val = properties[propName] = fullForm;
         }
         if (val) {
-            if (EDITOR) {
-                if ('default' in val) {
-                    if (val.get) {
-                        errorID(5513, className, propName);
-                    } else if (val.set) {
-                        errorID(5514, className, propName);
-                    } else if (legacyCC.Class._isCCClass(val.default)) {
-                        val.default = null;
-                        errorID(5515, className, propName);
-                    }
-                }
-            }
             if (DEV && !val.override && cls.__props__.indexOf(propName) !== -1) {
                 // check override
                 const baseClass = js.getClassName(getBaseClassWherePropertyDefined_DEV(propName, cls));

--- a/cocos/core/data/utils/preprocess-class.ts
+++ b/cocos/core/data/utils/preprocess-class.ts
@@ -170,7 +170,7 @@ export function preprocessAttrs (properties, className, cls): void {
 }
 
 const CALL_SUPER_DESTROY_REG_DEV = /\b\._super\b|destroy.*\.call\s*\(\s*\w+\s*[,|)]/;
-export function validateOverrideMethods_DEV (cls, base, className): void {
+export function validateOverrideMethods_DEV (cls: Function, base: Function | undefined, className: string): void {
     const proto = cls.prototype;
     const destroy = proto.destroy;
     if (destroy && proto.hasOwnProperty?.('destroy')) {

--- a/cocos/core/data/utils/preprocess-class.ts
+++ b/cocos/core/data/utils/preprocess-class.ts
@@ -31,13 +31,6 @@ import { legacyCC } from '../../global-exports';
 
 // 增加预处理属性这个步骤的目的是降低 CCClass 的实现难度，将比较稳定的通用逻辑和一些需求比较灵活的属性需求分隔开。
 
-const SerializableAttrs = {
-    default: {},
-    serializable: {},
-    editorOnly: {},
-    formerlySerializedAs: {},
-};
-
 function parseType (val, type, className, propName): void {
     const STATIC_CHECK = (EDITOR && DEV) || TEST;
 

--- a/cocos/core/data/utils/preprocess-class.ts
+++ b/cocos/core/data/utils/preprocess-class.ts
@@ -234,17 +234,13 @@ export function preprocessAttrs (properties, className, cls): void {
 }
 
 const CALL_SUPER_DESTROY_REG_DEV = /\b\._super\b|destroy.*\.call\s*\(\s*\w+\s*[,|)]/;
-export function doValidateMethodWithProps_DEV (func, funcName, className, cls, base): false | undefined {
-    if (cls.__props__ && cls.__props__.indexOf(funcName) >= 0) {
-        // find class that defines this method as a property
-        const baseClassName = js.getClassName(getBaseClassWherePropertyDefined_DEV(funcName, cls));
-        errorID(3648, className, funcName, baseClassName);
-        return false;
-    }
-    if (funcName === 'destroy'
-        && js.isChildClassOf(base, legacyCC.Component)
-        && !CALL_SUPER_DESTROY_REG_DEV.test(func)
-    ) {
-        error(`Overwriting '${funcName}' function in '${className}' class without calling super is not allowed. Call the super function in '${funcName}' please.`);
+export function validateOverrideMethods_DEV (cls, base, className): void {
+    const proto = cls.prototype;
+    const destroy = proto.destroy;
+    if (destroy && proto.hasOwnProperty?.('destroy')) {
+        if (js.isChildClassOf(base, legacyCC.Component)
+            && !CALL_SUPER_DESTROY_REG_DEV.test(destroy)) {
+            error(`Overwriting '${'destroy'}' function in '${className}' class without calling super is not allowed. Call the super function in '${'destroy'}' please.`);
+        }
     }
 }

--- a/cocos/scene-graph/component.ts
+++ b/cocos/scene-graph/component.ts
@@ -31,10 +31,9 @@ import { IDGenerator } from '../core/utils/id-generator';
 import { getClassName, value } from '../core/utils/js';
 import { RenderScene } from '../render-scene/core/render-scene';
 import { Rect } from '../core/math';
-import * as RF from '../core/data/utils/requiring-frame';
 import { Node } from './node';
 import { legacyCC } from '../core/global-exports';
-import { errorID, warnID, assertID } from '../core/platform/debug';
+import { errorID, assertID } from '../core/platform/debug';
 import { CompPrefabInfo } from './prefab/prefab-info';
 import { EventHandler } from './component-event-handler';
 
@@ -733,81 +732,6 @@ if (EDITOR || TEST) {
     // TODO Keep temporarily, compatible with old version
     legacyCC._componentMenuItems = [];
 }
-
-// we make this non-enumerable, to prevent inherited by sub classes.
-value(Component, '_registerEditorProps', (cls, props): void => {
-    let reqComp = props.requireComponent;
-    if (reqComp) {
-        if (Array.isArray(reqComp)) {
-            reqComp = reqComp.filter(Boolean);
-        }
-        cls._requireComponent = reqComp;
-    }
-    const order = props.executionOrder;
-    if (order && typeof order === 'number') {
-        cls._executionOrder = order;
-    }
-    if (EDITOR || TEST) {
-        const name = getClassName(cls);
-        for (const key in props) {
-            const val = props[key];
-            switch (key) {
-            case 'executeInEditMode':
-                cls._executeInEditMode = !!val;
-                break;
-
-            case 'playOnFocus':
-                if (val) {
-                    const willExecuteInEditMode = ('executeInEditMode' in props) ? props.executeInEditMode : cls._executeInEditMode;
-                    if (willExecuteInEditMode) {
-                        cls._playOnFocus = true;
-                    } else {
-                        warnID(3601, name);
-                    }
-                }
-                break;
-
-            case 'inspector':
-                value(cls, '_inspector', val, true);
-                break;
-
-            case 'icon':
-                value(cls, '_icon', val, true);
-                break;
-
-            case 'menu':
-            {
-                const frame = RF.peek();
-                let menu = val;
-                if (frame && !menu.includes('/')) {
-                    menu = `i18n:menu.custom_script/${menu}`;
-                }
-
-                EDITOR && EditorExtends.Component.removeMenu(cls);
-                EDITOR && EditorExtends.Component.addMenu(cls, menu, props.menuPriority);
-                break;
-            }
-
-            case 'disallowMultiple':
-                cls._disallowMultiple = cls;
-                break;
-
-            case 'requireComponent':
-            case 'executionOrder':
-                // skip here
-                break;
-
-            case 'help':
-                cls._help = val;
-                break;
-
-            default:
-                warnID(3602, key, name);
-                break;
-            }
-        }
-    }
-});
 
 legacyCC.Component = Component;
 export { Component };


### PR DESCRIPTION
系列 PR，待合并到主仓库时再用英文。
之前的 CCClass 实现是基于 ES5 的 cc.Class API，现在都升级到装饰器后中间的很多步骤可以省略和简化了。

目标是减小引擎的核心包体、加快引擎加载性能，尤其是编辑器下的加载性能。

Changelog:
 - [x] 直接在 class 装饰器上实现 editor 相关的组件接口
 - [x] 简化 CCClass 的初始化代码

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->